### PR TITLE
change resin to balenalib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian
+FROM balenalib/raspberrypi3
 MAINTAINER gabrielrf
 # Originally made by: https://github.com/matteoredaelli/docker-mongodb-rpi
 


### PR DESCRIPTION
resin base images have been deprecated
in favour of the new balenalib images,
read more about it in our docs:
https://www.balena.io/docs/reference/base-images/base-images/
Source: resin/rpi-raspbian instalation